### PR TITLE
Add support for rasing with a specific traceback

### DIFF
--- a/vine/five.py
+++ b/vine/five.py
@@ -50,3 +50,27 @@ def with_metaclass(Type, skip_attrs={'__dict__', '__weakref__'}):
         return Type(Class.__name__, Class.__bases__, attrs)
 
     return _clone_with_metaclass
+
+if PY3:
+    def reraise(tp, value, tb=None):
+        if value.__traceback__ is not tb:
+            raise value.with_traceback(tb)
+        raise value
+
+else:
+    def exec_(_code_, _globs_=None, _locs_=None):
+        """Execute code in a namespace."""
+        if _globs_ is None:
+            frame = sys._getframe(1)
+            _globs_ = frame.f_globals
+            if _locs_ is None:
+                _locs_ = frame.f_locals
+            del frame
+        elif _locs_ is None:
+            _locs_ = _globs_
+        exec("""exec _code_ in _globs_, _locs_""")
+
+
+    exec_("""def reraise(tp, value, tb=None):
+    raise tp, value, tb
+""")

--- a/vine/promises.py
+++ b/vine/promises.py
@@ -5,6 +5,7 @@ import sys
 from collections import deque
 
 from .abstract import Thenable
+from .five import reraise
 
 __all__ = ['promise']
 
@@ -128,7 +129,7 @@ class promise(object):
                 retval = self.fun(*final_args, **final_kwargs)
                 self.value = (ca, ck) = (retval,), {}
             except Exception:
-                return self.set_error_state()
+                return self.throw()
         else:
             self.value = (ca, ck) = final_args, final_kwargs
         self.ready = True
@@ -176,7 +177,7 @@ class promise(object):
         if self.on_error:
             self.on_error(exc)
 
-    def set_error_state(self, exc=None):
+    def throw(self, exc=None, tb=None):
         if self.cancelled:
             return
         _exc = sys.exc_info()[1] if exc is None else exc
@@ -199,7 +200,7 @@ class promise(object):
             if self.on_error is None:
                 if exc is None:
                     raise
-                raise exc
+                reraise(type(exc), exc, tb)
 
     @property
     def listeners(self):
@@ -207,11 +208,4 @@ class promise(object):
             return self._lvpending
         return [self._svpending]
 
-    def throw(self, exc=None):
-        if exc is None:
-            return self.set_error_state()
-        try:
-            raise exc
-        except exc.__class__ as with_cause:
-            self.set_error_state(with_cause)
 Thenable.register(promise)


### PR DESCRIPTION
This also simplifies the Promise a bit - seems the extra wrapping in Promise.throw is not necessary.

@ask I need these changes for the new PR I'm going to make on celery's master (for that cross-process traceback thing).