### PR TITLE
Convert readthedocs link for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,7 @@
 |build-status| |coverage| |bitdeli|
 
 :Version: 1.1.1
-:Web: http://vine.readthedocs.org/
+:Web: https://vine.readthedocs.io/
 :Download: http://pypi.python.org/pypi/vine/
 :Source: http://github.com/celery/vine/
 :Keywords: promise, async, future

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -9,7 +9,7 @@ globals().update(conf.build_config(
     description='Python Promises',
     # version_dev='2.0',
     # version_stable='1.0',
-    canonical_url='http://vine.readthedocs.org',
+    canonical_url='https://vine.readthedocs.io',
     webdomain='celeryproject.org',
     github_project='celery/vine',
     author='Ask Solem & contributors',

--- a/docs/includes/introduction.txt
+++ b/docs/includes/introduction.txt
@@ -1,5 +1,5 @@
 :Version: 1.1.1
-:Web: http://vine.readthedocs.org/
+:Web: https://vine.readthedocs.io/
 :Download: http://pypi.python.org/pypi/vine/
 :Source: http://github.com/celery/vine/
 :Keywords: promise, async, future


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.