### PR TITLE
Fixed import to resolve DeprecationWarning

### DIFF
--- a/vine/five.py
+++ b/vine/five.py
@@ -48,7 +48,10 @@ PY2 = sys.version_info[0] < 3
 try:
     reload = reload                         # noqa
 except NameError:                           # pragma: no cover
-    from imp import reload                  # noqa
+    try:
+        from importlib import reload        # noqa
+    except ImportError:                     # pragma: no cover
+        from imp import reload              # noqa
 
 try:
     from collections import UserList        # noqa


### PR DESCRIPTION
Fixes "DeprecationWarning: the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses".
We still keep fallback for Python < 3.4