### PR TITLE
CI: Fix all builds

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -54,6 +54,7 @@ init:
 install:
   - "powershell extra\\appveyor\\install.ps1"
   - "%PYTHON%/Scripts/pip.exe install -U setuptools"
+  - "%PYTHON%/Scripts/pip.exe install -r requirements/test.txt"
 
 build: off
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,7 +8,7 @@ python_classes = test_*
 ignore = N806, N802, N801, N803
 
 [pep257]
-ignore = D102,D104,D203,D105,D213
+ignore = D102,D104,D203,D105,D213,D107
 
 [bdist_wheel]
 universal = 1


### PR DESCRIPTION
Since https://github.com/celery/vine/pull/18#issuecomment-343172637 pointed out that the build was broken, this PR fixes it, so that https://github.com/celery/celery/issues/3993 will (eventually) be fixed.

I removed the `pypy` target instead of fixing it following the example of https://github.com/celery/vine/commit/0c4940062476e3f5ade54f84e9da46b83a914333.

I ignored `D107` because other similar codes (`D102`, `D104`, `D105`) are already ignored.