### PR TITLE
Update all pypi.python.org URLs to pypi.org

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,7 +6,7 @@
 
 :Version: 1.1.4
 :Web: https://vine.readthedocs.io/
-:Download: http://pypi.python.org/pypi/vine/
+:Download: https://pypi.org/project/vine/
 :Source: http://github.com/celery/vine/
 :Keywords: promise, async, future
 
@@ -27,13 +27,13 @@ About
 
 .. |wheel| image:: https://img.shields.io/pypi/wheel/vine.svg
     :alt: Vine can be installed via wheel
-    :target: http://pypi.python.org/pypi/vine/
+    :target: https://pypi.org/project/vine/
 
 .. |pyversion| image:: https://img.shields.io/pypi/pyversions/vine.svg
     :alt: Supported Python versions.
-    :target: http://pypi.python.org/pypi/vine/
+    :target: https://pypi.org/project/vine/
 
 .. |pyimp| image:: https://img.shields.io/pypi/implementation/vine.svg
     :alt: Support Python implementations.
-    :target: http://pypi.python.org/pypi/vine/
+    :target: https://pypi.org/project/vine/
 

--- a/docs/includes/introduction.txt
+++ b/docs/includes/introduction.txt
@@ -1,6 +1,6 @@
 :Version: 1.1.4
 :Web: https://vine.readthedocs.io/
-:Download: http://pypi.python.org/pypi/vine/
+:Download: https://pypi.org/project/vine/
 :Source: http://github.com/celery/vine/
 :Keywords: promise, async, future
 

--- a/docs/templates/readme.txt
+++ b/docs/templates/readme.txt
@@ -19,12 +19,12 @@
 
 .. |wheel| image:: https://img.shields.io/pypi/wheel/vine.svg
     :alt: Vine can be installed via wheel
-    :target: http://pypi.python.org/pypi/vine/
+    :target: https://pypi.org/project/vine/
 
 .. |pyversion| image:: https://img.shields.io/pypi/pyversions/vine.svg
     :alt: Supported Python versions.
-    :target: http://pypi.python.org/pypi/vine/
+    :target: https://pypi.org/project/vine/
 
 .. |pyimp| image:: https://img.shields.io/pypi/implementation/vine.svg
     :alt: Support Python implementations.
-    :target: http://pypi.python.org/pypi/vine/
+    :target: https://pypi.org/project/vine/

--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,7 @@ def reqs(f):
 if os.path.exists('README.rst'):
     long_description = codecs.open('README.rst', 'r', 'utf-8').read()
 else:
-    long_description = 'See http://pypi.python.org/pypi/vine'
+    long_description = 'See https://pypi.org/project/vine/'
 
 # -*- Entry Points -*- #
 


### PR DESCRIPTION
For details on the new PyPI, see the blog post:

https://pythoninsider.blogspot.ca/2018/04/new-pypi-launched-legacy-pypi-shutting.html