### PR TITLE
Fix py3.7 DeprecationWarning importing collections.Callable

### DIFF
--- a/vine/abstract.py
+++ b/vine/abstract.py
@@ -3,9 +3,7 @@ from __future__ import absolute_import, unicode_literals
 
 import abc
 
-from collections import Callable
-
-from .five import with_metaclass
+from .five import with_metaclass, Callable
 
 __all__ = ['Thenable']
 

--- a/vine/five.py
+++ b/vine/five.py
@@ -30,7 +30,7 @@ except NameError:  # pragma: no cover
 bytes_t = bytes
 
 __all__ = [
-    'Counter', 'reload', 'UserList', 'UserDict',
+    'Counter', 'reload', 'UserList', 'UserDict', 'Callable',
     'Queue', 'Empty', 'Full', 'LifoQueue', 'builtins', 'array',
     'zip_longest', 'map', 'zip', 'string', 'string_t', 'bytes_t',
     'bytes_if_py2', 'long_t', 'text_t', 'int_types', 'module_name_t',
@@ -62,6 +62,11 @@ try:
     from collections import UserDict        # noqa
 except ImportError:                         # pragma: no cover
     from UserDict import UserDict           # noqa
+
+try:
+    from collections.abc import Callable    # noqa
+except ImportError:                         # pragma: no cover
+    from collections import Callable        # noqa
 
 #  ############# time.monotonic #############################################
 

--- a/vine/five.py
+++ b/vine/five.py
@@ -30,7 +30,8 @@ except NameError:  # pragma: no cover
 bytes_t = bytes
 
 __all__ = [
-    'Counter', 'reload', 'UserList', 'UserDict', 'Callable',
+    'Counter', 'reload', 'UserList', 'UserDict',
+    'Callable', 'Iterable', 'Mapping',
     'Queue', 'Empty', 'Full', 'LifoQueue', 'builtins', 'array',
     'zip_longest', 'map', 'zip', 'string', 'string_t', 'bytes_t',
     'bytes_if_py2', 'long_t', 'text_t', 'int_types', 'module_name_t',
@@ -67,6 +68,16 @@ try:
     from collections.abc import Callable    # noqa
 except ImportError:                         # pragma: no cover
     from collections import Callable        # noqa
+
+try:
+    from collections.abc import Iterable    # noqa
+except ImportError:                         # pragma: no cover
+    from collections import Iterable        # noqa
+
+try:
+    from collections.abc import Mapping     # noqa
+except ImportError:                         # pragma: no cover
+    from collections import Mapping         # noqa
 
 #  ############# time.monotonic #############################################
 


### PR DESCRIPTION
It was deprecated in python 3.3 and will stop working in 3.8, new name is `collections.abc.Callable`.

The full warning is:

>DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working