### PR TITLE
Handle bound methods in weak reference promise instances

### DIFF
--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -16,3 +16,4 @@
     vine.abstract
     vine.five
     vine.utils
+    vine.backports.weakref_backports

--- a/docs/reference/vine.backports.rst
+++ b/docs/reference/vine.backports.rst
@@ -1,0 +1,11 @@
+=====================================================
+ vine.backports
+=====================================================
+
+.. contents::
+    :local:
+.. currentmodule:: vine.backports
+
+.. automodule:: vine.backports
+    :members:
+    :undoc-members:

--- a/docs/reference/vine.backports.weakref_backports.rst
+++ b/docs/reference/vine.backports.weakref_backports.rst
@@ -1,0 +1,11 @@
+=====================================================
+vine.backports.weakref_backports
+=====================================================
+
+.. contents::
+    :local:
+.. currentmodule:: vine.backports.weakref_backports
+
+.. automodule:: vine.backports.weakref_backports
+    :members:
+    :undoc-members:

--- a/t/unit/test_promises.py
+++ b/t/unit/test_promises.py
@@ -6,6 +6,7 @@ import traceback
 
 from collections import deque
 from struct import pack, unpack
+import weakref
 
 from case import Mock
 
@@ -323,3 +324,26 @@ class test_promise:
         d = promise(Mock(name='d'), on_error=de)
         p2.then(d)
         de.fun.assert_called_with(exc)
+
+    def test_weak_reference_unbound(self):
+        def f(x):
+            return x ** 2
+
+        promise_f = promise(f, weak=True)
+
+        assert isinstance(promise_f.fun, weakref.ref)
+        assert promise_f(2) == 4
+
+    def test_weak_reference_bound(self):
+        class Example(object):
+            def __init__(self, y):
+                self.y = y
+
+            def f(self, x):
+                return self.y + x ** 2
+
+        example = Example(5)
+        promise_f = promise(example.f, weak=True)
+
+        assert isinstance(promise_f.fun, weakref.ref)
+        assert promise_f(2) == 9

--- a/vine/backports/weakref_backports.py
+++ b/vine/backports/weakref_backports.py
@@ -1,0 +1,71 @@
+"""Weakref compatibility.
+
+weakref_backports is a partial backport of the weakref module for Python
+versions below 3.4.
+
+Copyright (C) 2013 Python Software Foundation, see LICENSE.python for details.
+
+The following changes were made to the original sources during backporting:
+
+* Added ``self`` to ``super`` calls.
+* Removed ``from None`` when raising exceptions.
+"""
+from __future__ import absolute_import, unicode_literals
+
+from weakref import ref
+
+
+class WeakMethod(ref):
+    """Weak reference to bound method.
+
+    A custom :class:`weakref.ref` subclass which simulates a weak reference
+    to a bound method, working around the lifetime problem of bound methods.
+    """
+
+    __slots__ = '_func_ref', '_meth_type', '_alive', '__weakref__'
+
+    def __new__(cls, meth, callback=None):
+        try:
+            obj = meth.__self__
+            func = meth.__func__
+        except AttributeError:
+            raise TypeError(
+                "Argument should be a bound method, not {0}".format(
+                    type(meth)))
+
+        def _cb(arg):
+            # The self-weakref trick is needed to avoid creating a
+            # reference cycle.
+            self = self_wr()
+            if self._alive:
+                self._alive = False
+                if callback is not None:
+                    callback(self)
+        self = ref.__new__(cls, obj, _cb)
+        self._func_ref = ref(func, _cb)
+        self._meth_type = type(meth)
+        self._alive = True
+        self_wr = ref(self)
+        return self
+
+    def __call__(self):
+        obj = super(WeakMethod, self).__call__()
+        func = self._func_ref()
+        if obj is not None and func is not None:
+            return self._meth_type(func, obj)
+
+    def __eq__(self, other):
+        if not isinstance(other, WeakMethod):
+            return False
+        if not self._alive or not other._alive:
+            return self is other
+        return ref.__eq__(self, other) and self._func_ref == other._func_ref
+
+    def __ne__(self, other):
+        if not isinstance(other, WeakMethod):
+            return True
+        if not self._alive or not other._alive:
+            return self is not other
+        return ref.__ne__(self, other) or self._func_ref != other._func_ref
+
+    __hash__ = ref.__hash__


### PR DESCRIPTION
- [x] Add backport of weakref.WeakMethod for Python version where
  this is not available as part of the standard library.
- [x] Add test cases for using weak references when creating a promise
  instance.

Closes #21 .