### PR TITLE
Add testing and document support for Python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: xenial
 language: python
 sudo: false
 cache: pip
@@ -16,8 +17,12 @@ matrix:
       env: TOXENV=3.5
     - python: 3.6
       env: TOXENV=3.6
-    - python: pypy
+    - python: 3.7
+      env: TOXENV=3.7
+    - python: pypy2.7-6.0
       env: TOXENV=pypy
+    - python: pypy3.5-6.0
+      env: TOXENV=pypy3
     - env: TOXENV=flake8
     - env: TOXENV=flakeplus
     - env: TOXENV=apicheck

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ classes = """
     Programming Language :: Python :: 3.4
     Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
     Programming Language :: Python :: Implementation :: CPython
     Programming Language :: Python :: Implementation :: PyPy
     License :: OSI Approved :: BSD License

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,9 @@ envlist =
     3.4
     3.5
     3.6
+    3.7
     pypy
+    pypy3
     flake8
     flakeplus
     apicheck
@@ -21,13 +23,6 @@ deps=
 sitepackages = False
 recreate = False
 commands = py.test -xv --cov=vine --cov-report=xml --no-cov-on-fail
-
-basepython =
-    2.7,flakeplus,flake8,apicheck,linkcheck,pydocstyle,cov: python2.7
-    3.4: python3.4
-    3.5: python3.5
-    3.6: python3.6
-    pypy: pypy
 
 [testenv:apicheck]
 commands =


### PR DESCRIPTION
Python 3.7 was released on June 27, 2018.

https://docs.python.org/3/whatsnew/3.7.html

Use 'dist: xenial' in Travis for  Python 3.7 support.

https://blog.travis-ci.com/2018-11-08-xenial-release

Using PyPy on Xenial requires an explicit version, see:

https://travis-ci.community/t/pypy-2-7-on-xenial/889

Can drop basepython from the tox.ini, and rely on defaults:

https://tox.readthedocs.io/en/latest/config.html#conf-basepython

> If not specified, the virtual environments factors (e.g. name part)
> will be used to automatically set one. For example, py37 means
> python3.7, py3 means python3 and py means python.