### PR TITLE
Update setup.py to drop support for Python 2.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,9 +8,6 @@ import codecs
 import setuptools
 import setuptools.command.test
 
-if sys.version_info < (3, 4):
-    raise Exception('vine requires Python 3.4 or higher.')
-
 NAME = 'vine'
 
 # -*- Classifiers -*-
@@ -19,7 +16,6 @@ classes = """
     Development Status :: 5 - Production/Stable
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.4
     Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
@@ -110,7 +106,7 @@ setuptools.setup(
     platforms=['any'],
     classifiers=classifiers,
     license='BSD',
-    python_requires=">=3.4",
+    python_requires=">=3.5",
     install_requires=[],
     tests_require=reqs('test.txt'),
     cmdclass={'test': pytest},

--- a/setup.py
+++ b/setup.py
@@ -8,8 +8,8 @@ import codecs
 import setuptools
 import setuptools.command.test
 
-if sys.version_info < (2, 7):
-    raise Exception('vine requires Python 2.7 or higher.')
+if sys.version_info < (3, 4):
+    raise Exception('vine requires Python 3.4 or higher.')
 
 NAME = 'vine'
 
@@ -18,8 +18,6 @@ NAME = 'vine'
 classes = """
     Development Status :: 5 - Production/Stable
     Programming Language :: Python
-    Programming Language :: Python :: 2
-    Programming Language :: Python :: 2.7
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3.4
     Programming Language :: Python :: 3.5
@@ -112,7 +110,7 @@ setuptools.setup(
     platforms=['any'],
     classifiers=classifiers,
     license='BSD',
-    python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*",
+    python_requires=">=3.4",
     install_requires=[],
     tests_require=reqs('test.txt'),
     cmdclass={'test': pytest},


### PR DESCRIPTION
From celery#31 looks like Vine dropped support for Python 2. Since https://pypi.org/project/vine/5.0.0a1/ is published with Python 2.7 still listed in the setup.py python_requires, that version could get installed as a transitive dependency for Python 2 apps.

Setting minimum python version to 3.4.