### PR TITLE
update classifier to show that python 3.6 is not supported

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,6 @@ classes = """
     Development Status :: 5 - Production/Stable
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9


### PR DESCRIPTION
python_requires=">=3.6", was kept intentionally