### PR TITLE
tests: Replace deprecated setup method

### DIFF
--- a/t/unit/test_synchronization.py
+++ b/t/unit/test_synchronization.py
@@ -8,7 +8,7 @@ from vine.synchronization import barrier
 
 class test_barrier:
 
-    def setup(self):
+    def setup_method(self):
         self.m1, self.m2, self.m3 = Mock(), Mock(), Mock()
         self.ps = [promise(self.m1), promise(self.m2), promise(self.m3)]
 


### PR DESCRIPTION
Nose's `setup` method is deprecated since Pytest 7.2.

See https://docs.pytest.org/en/stable/deprecations.html#support-for-tests-written-for-nose for details.

Fixes: https://github.com/celery/vine/issues/104