### PR TITLE
setup.cfg: Stop using deprecated license_file alias

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,7 @@ extend-ignore = N806, N802, N801, N803
 universal = 0
 
 [metadata]
-license_file = LICENSE
+license_files = LICENSE
 
 [isort]
 profile=black


### PR DESCRIPTION
Noticed while packaging 5.1.0 for Debian.